### PR TITLE
Fix linking in macOS mojave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+examples/viewer/viewer
+examples/viewer/viewer.dSYM
+*.o

--- a/examples/viewer/Makefile
+++ b/examples/viewer/Makefile
@@ -1,6 +1,6 @@
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-LD_FLAGS=-framework OpenGL -lglfw3 -lglew
+LD_FLAGS=-framework OpenGL -lglfw3 -lglew -framework Cocoa -framework IOKit -framework CoreVideo
 endif
 ifeq ($(UNAME_S),Linux)
 LD_FLAGS=-lGL -lGLU -lglfw3 -lGLEW -lX11 -lXrandr -lXinerama -lXxf86vm -lXcursor -lm -pthread -ldl

--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -89,8 +89,8 @@ typedef struct {
 
 /* Parse wavefront .obj(.obj string data is expanded to linear char array `buf')
  * flags are combination of TINYOBJ_FLAG_***
- * Retruns TINYOBJ_SUCCESS if things goes well.
- * Retruns TINYOBJ_ERR_*** when there is an error.
+ * Returns TINYOBJ_SUCCESS if things goes well.
+ * Returns TINYOBJ_ERR_*** when there is an error.
  */
 extern int tinyobj_parse_obj(tinyobj_attrib_t *attrib, tinyobj_shape_t **shapes,
                              size_t *num_shapes, tinyobj_material_t **materials,


### PR DESCRIPTION
This change fixes linking in macOS mojave. The Cocoa, IOKit and CoreVideo frameworks are required.

Additional changes:
* Add .gitignore
* Fix typos