### PR TITLE
Include face if last line in file

### DIFF
--- a/examples/viewer/viewer.c
+++ b/examples/viewer/viewer.c
@@ -207,7 +207,7 @@ static int LoadObjAndConvert(float bmin[3], float bmax[3],
     }
 
     printf("# of shapes    = %d\n", (int)num_shapes);
-    printf("# of materiasl = %d\n", (int)num_materials);
+    printf("# of materials = %d\n", (int)num_materials);
 
     /*
     {

--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -1194,12 +1194,12 @@ int tinyobj_parse_obj(tinyobj_attrib_t *attrib, tinyobj_shape_t **shapes,
    /* 1. Find '\n' and create line data. */
   {
     size_t i;
-    size_t end_idx = len - 1;
+    size_t end_idx = len;
     size_t prev_pos = 0;
     size_t line_no = 0;
 
     /* Count # of lines. */
-    for (i = 0; i < end_idx; i++) { /* Assume last char is '\0' */
+    for (i = 0; i < end_idx; i++) {
       if (is_line_ending(buf, i, end_idx)) {
         num_lines++;
       }
@@ -1209,7 +1209,7 @@ int tinyobj_parse_obj(tinyobj_attrib_t *attrib, tinyobj_shape_t **shapes,
 
     line_infos = (LineInfo *)malloc(sizeof(LineInfo) * num_lines);
 
-    /* Fill line infoss. */
+    /* Fill line infos. */
     for (i = 0; i < end_idx; i++) {
       if (is_line_ending(buf, i, end_idx)) {
         line_infos[line_no].pos = prev_pos;

--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -1197,12 +1197,21 @@ int tinyobj_parse_obj(tinyobj_attrib_t *attrib, tinyobj_shape_t **shapes,
     size_t end_idx = len;
     size_t prev_pos = 0;
     size_t line_no = 0;
+    size_t last_line_ending = 0;
 
     /* Count # of lines. */
     for (i = 0; i < end_idx; i++) {
       if (is_line_ending(buf, i, end_idx)) {
         num_lines++;
+        last_line_ending = i;
       }
+    }
+    /* The last char from the input may not be a line
+     * ending character so add an extra line if there
+     * are more characters after the last line ending
+     * that was found. */
+    if (end_idx - last_line_ending > 0) {
+        num_lines++;
     }
 
     if (num_lines == 0) return TINYOBJ_ERROR_EMPTY;
@@ -1217,6 +1226,10 @@ int tinyobj_parse_obj(tinyobj_attrib_t *attrib, tinyobj_shape_t **shapes,
         prev_pos = i + 1;
         line_no++;
       }
+    }
+    if (end_idx - last_line_ending > 0) {
+      line_infos[line_no].pos = prev_pos;
+      line_infos[line_no].len = end_idx - 1 - last_line_ending;
     }
   }
 


### PR DESCRIPTION
Take two.

The reason this change is necessary is because the raw .obj data might not be null terminated. This means that there might be content between the end of the file and the last found line end.

Taking the viewer as an example, mmap returns a `char*` of just the number of bytes requested and does not include a null character at the end. If there are no empty lines at the end of the file, as in the example in #12, the last face is ignored.