### PR TITLE
hash_table_insert_value: Correctly set next entry

### DIFF
--- a/test/tinyobj_internal_tests.c
+++ b/test/tinyobj_internal_tests.c
@@ -868,3 +868,39 @@ void test_hash_table_get(void)
 
     destroy_hash_table(&table);
 }
+
+void test_hash_table_maybe_grow(void)
+{
+    // It should be possible for the table to grow, preserving all previous values
+    hash_table_t table;
+    create_hash_table(10, &table);
+
+    hash_table_set("Pottery_clay0", 0, &table);
+    hash_table_set("Dark_smoked_gla0", 1, &table);
+    hash_table_set("Pottery_clay1", 2, &table);
+    hash_table_set("Dark_smoked_gla1", 3, &table);
+    hash_table_set("Metallic_Varni0", 4, &table);
+    hash_table_set("Body0", 5, &table);
+    hash_table_set("Pottery_clay2", 6, &table);
+    hash_table_set("850matri0", 7, &table);
+    hash_table_set("850matri1", 8, &table);
+    hash_table_set("Pottery_clay3", 9, &table);
+    hash_table_set("Pottery_clay4", 10, &table);
+
+    TEST_CHECK(table.capacity > 10);
+    TEST_CHECK(table.n == 11);
+
+    TEST_CHECK(hash_table_get("Pottery_clay0", &table) == 0);
+    TEST_CHECK(hash_table_get("Dark_smoked_gla0", &table) == 1);
+    TEST_CHECK(hash_table_get("Pottery_clay1", &table) == 2);
+    TEST_CHECK(hash_table_get("Dark_smoked_gla1", &table) == 3);
+    TEST_CHECK(hash_table_get("Metallic_Varni0", &table) == 4);
+    TEST_CHECK(hash_table_get("Body0", &table) == 5);
+    TEST_CHECK(hash_table_get("Pottery_clay2", &table) == 6);
+    TEST_CHECK(hash_table_get("850matri0", &table) == 7);
+    TEST_CHECK(hash_table_get("850matri1", &table) == 8);
+    TEST_CHECK(hash_table_get("Pottery_clay3", &table) == 9);
+    TEST_CHECK(hash_table_get("Pottery_clay4", &table) == 10);
+
+    destroy_hash_table(&table);
+}

--- a/test/tinyobj_internal_tests.h
+++ b/test/tinyobj_internal_tests.h
@@ -20,5 +20,6 @@ void test_create_hash_table(void);
 void test_hash_table_set(void);
 void test_hash_table_exists(void);
 void test_hash_table_get(void);
+void test_hash_table_maybe_grow(void);
 
 #endif

--- a/test/tinyobj_tests.c
+++ b/test/tinyobj_tests.c
@@ -29,6 +29,7 @@ TEST_LIST = {
     { "hash_table_set",         test_hash_table_set },
     { "hash_table_exists",      test_hash_table_exists },
     { "hash_table_get",         test_hash_table_get },
+    { "hash_table_maybe_grow",  test_hash_table_maybe_grow },
 
     { 0 } // required by acutest
 };


### PR DESCRIPTION
With the previous implementation entries would get lost (not reachable from their `start_index` anymore).
This would later on lead to a segfault in `hash_table_maybe_grow`, because `hash_table_find` returns `NULL` for entries in the table.

This can be reproduced using the following code:
```c
#define TINYOBJ_LOADER_C_IMPLEMENTATION
#include "tinyobj_loader_c.h"

int main(void) {
  hash_table_t table;
  create_hash_table(HASH_TABLE_DEFAULT_SIZE, &table);

  hash_table_set("Pottery_clay0", 0, &table);
  hash_table_set("Dark_smoked_gla0", 1, &table);
  hash_table_set("Pottery_clay1", 2, &table);
  hash_table_set("Dark_smoked_gla1", 3, &table);
  hash_table_set("Metallic_Varni0", 4, &table);
  hash_table_set("Body0", 5, &table);
  hash_table_set("Pottery_clay2", 6, &table);
  hash_table_set("850matri0", 7, &table);
  hash_table_set("850matri1", 8, &table);
  hash_table_set("Pottery_clay3", 9, &table);
  hash_table_set("Pottery_clay4", 10, &table); /* Segfaults */

  return EXIT_SUCCESS;
}
```

The last `hash_table_set` call will exceed the table's capacity, leading `hash_table_maybe_grow` to allocate new entries and rehash all existing ones. In the loop rehashing the entries, it is assumed `hash_table_find` may not return `NULL`, since we're iterating over the known hashes. Due to a bug in `hash_table_insert_value`, not all entries are reachable from their `start_index` anymore, proving this assumption wrong. In the next line, we're accessing `entry->next`, which will try to read from NULL + 0x10 == 0x10, which is an invalid address.

This simpler approach makes sure the entry can always be found by iterating through `entry->next` in `hash_table_find`.

Change loop to start from i=1, as with i=0 index will evaluate to start_index again.

Remove the `hash_table->entries[index].hash == hash` check, because this case cannot occur. `hash_table_insert_value` is only called from either `hash_table_maybe_grow`, in which case there can't be collisions, or `hash_table_set`, which would have found and updated the entry.

Also remove the unused `hash_table_erase` function so we don't have to keep track of the prev pointer anymore.

Add a test for `hash_table_maybe_grow`. This test triggers the aforementioned segfault in the old implementation.

Signed-off-by: Jan Erik Petersen <JanErikPetersen@web.de>