### PR TITLE
Print error message when failing to load mtl file

### DIFF
--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -110,6 +110,7 @@ extern void tinyobj_materials_free(tinyobj_material_t *materials,
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
+#include <errno.h>
 
 
 #define TINYOBJ_MAX_FACES_PER_F_LINE (16)
@@ -678,6 +679,7 @@ static int tinyobj_parse_and_index_mtl_file(tinyobj_material_t **materials_out,
 
   fp = fopen(filename, "r");
   if (!fp) {
+    fprintf(stderr, "TINYOBJ: Error reading file '%s': %s (%d)\n", filename, strerror(errno), errno);
     return TINYOBJ_ERROR_FILE_OPERATION;
   }
 
@@ -1242,7 +1244,7 @@ int tinyobj_parse_obj(tinyobj_attrib_t *attrib, tinyobj_shape_t **shapes,
 
     if (ret != TINYOBJ_SUCCESS) {
       /* warning. */
-      fprintf(stderr, "TINYOBJ: Failed to parse .mtl file: %s\n", filename);
+      fprintf(stderr, "TINYOBJ: Failed to parse material file '%s': %d\n", filename, ret);
     }
 
     free(filename);


### PR DESCRIPTION
This is not an ideal solution, since we don't want to do I/O at all.
But until we have a callback to load mtl files as described in #4 , this way the user can at least get the real error message to diagnose the problem. (Which in most cases is an incorrect relative path to the material file, which would be solved by the solution proposed in #4 as well.)

This unfortunately introduces an additional dependency on `<errno.h>`, so this change might not be favorable.