### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.h linguist-language=C
+*.c linguist-language=C


### PR DESCRIPTION
 This is for GitHub to properly detect and display .h files as C headers instead of C++ in the source code distribution and for labelling what language the project is written in.