### PR TITLE
Fixing issue #8: Option for replacing memory allocation and file I/O

### DIFF
--- a/test/tinyobj_api_tests.c
+++ b/test/tinyobj_api_tests.c
@@ -22,9 +22,8 @@ void test_tinyobj_attrib_init(void)
     TEST_CHECK(attrib.material_ids == NULL);
 }
 
-size_t loadFile(const char * filename, char ** buffer)
+void loadFile(const char * filename, char ** buffer, size_t * len)
 {
-    *buffer = NULL;
     long string_size = 0, read_size = 0;
     FILE * handler = fopen(filename, "r");
 
@@ -42,7 +41,7 @@ size_t loadFile(const char * filename, char ** buffer)
         fclose(handler);
     }
 
-    return (size_t) read_size;
+    *len = read_size;
 }
 
 void test_tinyobj_parse_mtl_file(void)
@@ -53,7 +52,7 @@ void test_tinyobj_parse_mtl_file(void)
         tinyobj_material_t * material;
         size_t num_materials;
 
-        TEST_CHECK(tinyobj_parse_mtl_file(&material, &num_materials, filename) == TINYOBJ_SUCCESS);
+        TEST_CHECK(tinyobj_parse_mtl_file(&material, &num_materials, filename, loadFile) == TINYOBJ_SUCCESS);
 
         TEST_CHECK(num_materials == 1);
         TEST_CHECK(strcmp(material->name, "CubeMaterial") == 0);
@@ -92,10 +91,7 @@ void test_tinyobj_parse_obj(void)
 
     tinyobj_attrib_init(&attrib);
 
-    char * obj_contents;
-    size_t file_size = loadFile(filename, &obj_contents);
-
-    int result = tinyobj_parse_obj(&attrib, &shape, &num_shapes, &material, &num_materials, obj_contents, file_size, TINYOBJ_FLAG_TRIANGULATE);
+    int result = tinyobj_parse_obj(&attrib, &shape, &num_shapes, &material, &num_materials, filename, loadFile, TINYOBJ_FLAG_TRIANGULATE);
 
     TEST_CHECK(result == TINYOBJ_SUCCESS);
 

--- a/test/tinyobj_regression_tests.c
+++ b/test/tinyobj_regression_tests.c
@@ -16,7 +16,7 @@ static int float_equals(float x, float y)
   return 0;
 }
 
-static size_t loadFile(const char * filename, char ** buffer)
+static void loadFile(const char * filename, char ** buffer, size_t * len)
 {
     *buffer = NULL;
     long string_size = 0, read_size = 0;
@@ -36,7 +36,7 @@ static size_t loadFile(const char * filename, char ** buffer)
         fclose(handler);
     }
 
-    return (size_t) read_size;
+    *len = read_size;
 }
 
 void test_tinyobj_crlf_string(void)
@@ -47,7 +47,7 @@ void test_tinyobj_crlf_string(void)
         tinyobj_material_t * material;
         size_t num_materials;
 
-        TEST_CHECK(tinyobj_parse_mtl_file(&material, &num_materials, filename) == TINYOBJ_SUCCESS);
+        TEST_CHECK(tinyobj_parse_mtl_file(&material, &num_materials, filename, loadFile) == TINYOBJ_SUCCESS);
 
         TEST_CHECK(num_materials == 1);
         TEST_CHECK(strcmp(material->name, "CubeMaterial") == 0);
@@ -70,10 +70,7 @@ void test_tinyobj_negative_exponent(void)
 
         tinyobj_attrib_init(&attrib);
 
-        char * obj_contents;
-        size_t file_size = loadFile(filename, &obj_contents);
-
-        int result = tinyobj_parse_obj(&attrib, &shape, &num_shapes, &material, &num_materials, obj_contents, file_size, TINYOBJ_FLAG_TRIANGULATE);
+        int result = tinyobj_parse_obj(&attrib, &shape, &num_shapes, &material, &num_materials, filename, loadFile, TINYOBJ_FLAG_TRIANGULATE);
 
         TEST_CHECK(result == TINYOBJ_SUCCESS);
 


### PR DESCRIPTION
It seems that I can open a new pull request instead of reopening the previous one (#25 Add stdio macros).

Overview of my changes:
1. callback function to handle file reading
2. use callback in tinyobj_parse_obj and tinyobj_parse_mtl_file
3. parsing mtl needed more changes

I updated the tests and all passed. I also checked the viewer example.
More changes are coming because stdio.h dependency is still there.