### PR TITLE
mmap_file fixes for Windows

### DIFF
--- a/examples/viewer/viewer.c
+++ b/examples/viewer/viewer.c
@@ -88,14 +88,22 @@ static char* mmap_file(size_t* len, const char* filename) {
   HANDLE file =
       CreateFileA(filename, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
                   FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
-  assert(file != INVALID_HANDLE_VALUE);
+
+  if (file == INVALID_HANDLE_VALUE) { /* E.g. Model may not have materials. */
+    return NULL;
+  }
 
   HANDLE fileMapping = CreateFileMapping(file, NULL, PAGE_READONLY, 0, 0, NULL);
   assert(fileMapping != INVALID_HANDLE_VALUE);
 
   LPVOID fileMapView = MapViewOfFile(fileMapping, FILE_MAP_READ, 0, 0, 0);
-  auto fileMapViewChar = (const char*)fileMapView;
+  char* fileMapViewChar = (char*)fileMapView;
   assert(fileMapView != NULL);
+
+  DWORD file_size = GetFileSize(file, NULL);
+  (*len) = (size_t) file_size;
+
+  return fileMapViewChar;
 #else
 
   FILE* f;


### PR DESCRIPTION
Windows fixes to `mmap_file()` in viewer example:

1. Return NULL when a file doesn't exist. For example, a model may not have materials but can still continue to be parsed.

2. Remove `auto`. It won't work on a Windows compiler configured to compile only C.

3. Store file size through `len` pointer.

4. Properly return `fileMapViewChar` at the end of the function.

There's an open PR that handles items 3 and 4, but not 1 and 2. Mine is just these very minor changes that make the program work.