### PR TITLE
viewer: Add color drawing and other cleanups

### DIFF
--- a/examples/viewer/viewer.c
+++ b/examples/viewer/viewer.c
@@ -107,22 +107,9 @@ static char* mmap_file(size_t* len, const char* filename) {
   return fileMapViewChar;
 #else
 
-  FILE* f;
-  long file_size;
   struct stat sb;
   char* p;
   int fd;
-
-  (*len) = 0;
-
-  f = fopen(filename, "r");
-  if (!f) {
-    perror("open");
-    return NULL;
-  }
-  fseek(f, 0, SEEK_END);
-  file_size = ftell(f);
-  fclose(f);
 
   fd = open(filename, O_RDONLY);
   if (fd == -1) {
@@ -136,11 +123,11 @@ static char* mmap_file(size_t* len, const char* filename) {
   }
 
   if (!S_ISREG(sb.st_mode)) {
-    fprintf(stderr, "%s is not a file\n", "lineitem.tbl");
+    fprintf(stderr, "%s is not a file\n", filename);
     return NULL;
   }
 
-  p = (char*)mmap(0, (size_t)file_size, PROT_READ, MAP_SHARED, fd, 0);
+  p = (char*)mmap(0, sb.st_size, PROT_READ, MAP_SHARED, fd, 0);
 
   if (p == MAP_FAILED) {
     perror("mmap");
@@ -152,7 +139,7 @@ static char* mmap_file(size_t* len, const char* filename) {
     return NULL;
   }
 
-  (*len) = (size_t)file_size;
+  (*len) = sb.st_size;
 
   return p;
 

--- a/examples/viewer/viewer.c
+++ b/examples/viewer/viewer.c
@@ -212,14 +212,7 @@ static void get_file_data(void* ctx, const char* filename, const int is_mtl,
     }
 
     if (basedirname) {
-      strncpy(tmp, basedirname, strlen(basedirname) + 1);
-
-#if defined(_WIN32)
-      strncat(tmp, "/", 1023 - strlen(tmp));
-#else
-      strncat(tmp, "/", 1023 - strlen(tmp));
-#endif
-      strncat(tmp, filename, 1023 - strlen(tmp));
+      snprintf(tmp, sizeof(tmp) - 1, "%s/%s", basedirname, filename);
     } else {
       strncpy(tmp, filename, strlen(filename) + 1);
     }

--- a/examples/viewer/viewer.c
+++ b/examples/viewer/viewer.c
@@ -380,9 +380,17 @@ static int LoadObjAndConvert(float bmin[3], float bmax[3],
           vb[(3 * i + k) * stride + 8] = (c[2] * 0.5f + 0.5f);
 
 	  /* now set the color from the material */
-          vb[(3 * i + k) * stride + 9] = materials[attrib.material_ids[i]].diffuse[0];
-          vb[(3 * i + k) * stride + 10] = materials[attrib.material_ids[i]].diffuse[1];
-          vb[(3 * i + k) * stride + 11] = materials[attrib.material_ids[i]].diffuse[2];
+	  if (attrib.material_ids[i] >= 0) {
+	    int matidx = attrib.material_ids[i];
+	    vb[(3 * i + k) * stride + 9] = materials[matidx].diffuse[0];
+	    vb[(3 * i + k) * stride + 10] = materials[matidx].diffuse[1];
+	    vb[(3 * i + k) * stride + 11] = materials[matidx].diffuse[2];
+	  } else {
+	    /* Just copy the default value */
+	    vb[(3 * i + k) * stride + 9] = vb[(3 * i + k) * stride + 6];
+	    vb[(3 * i + k) * stride + 10] = vb[(3 * i + k) * stride + 7];
+	    vb[(3 * i + k) * stride + 11] = vb[(3 * i + k) * stride + 8];
+	  }
 
         }
       }

--- a/examples/viewer/viewer.c
+++ b/examples/viewer/viewer.c
@@ -44,7 +44,10 @@ static int height = 768;
 static bool use_colors = false;
 static bool draw_wireframe = true;
 
-static const size_t OBJ_SIZE = 48;
+static const size_t OBJ_SIZE = sizeof(float) * 3 // pos
+	+ sizeof(float) * 3 // normal
+	+ sizeof(float) * 3 // color (based on normal)
+	+ sizeof(float) * 3; // color from material file.
 
 static float prevMouseX, prevMouseY;
 static int mouseLeftPressed;
@@ -279,9 +282,9 @@ static int LoadObjAndConvert(float bmin[3], float bmax[3],
     size_t num_triangles = attrib.num_face_num_verts;
     size_t stride =
         OBJ_SIZE /
-        sizeof(float); /* 12 = pos(3float), normal(3float), color(3float) */
+        sizeof(float);
 
-    vb = (float*)malloc(OBJ_SIZE * num_triangles);
+    vb = (float*)malloc(OBJ_SIZE * num_triangles * 3);
 
     for (i = 0; i < attrib.num_face_num_verts; i++) {
       size_t f;


### PR DESCRIPTION
Simplify the way mmap gets the file size to avoid a syscall

Use snprintf to generate the path, not the current error prone way.

Add the ability to draw the color from the material file.  Toggle using 'c' or back to the normal.
Also add 'w' to toggle the wireframe on or off.