### PR TITLE
Add functionality to find mtl file in-library

### DIFF
--- a/examples/viewer/viewer.c
+++ b/examples/viewer/viewer.c
@@ -197,44 +197,9 @@ static void get_file_data(void* ctx, const char* filename, const int is_mtl,
     return;
   }
 
-  const char* ext = strrchr(filename, '.');
-
   size_t data_len = 0;
 
-  if (strcmp(ext, ".gz") == 0) {
-    assert(0); /* todo */
-
-  } else {
-    char* basedirname = NULL;
-
-    char tmp[1024];
-    tmp[0] = '\0';
-
-    /* For .mtl, extract base directory path from .obj filename and append .mtl
-     * filename */
-    if (is_mtl && obj_filename) {
-      /* my_strdup is from tinyobjloader-c.h implementation(since strdup is not
-       * a C standard library function */
-      basedirname = my_strdup(obj_filename, strlen(obj_filename));
-      basedirname = get_dirname(basedirname);
-      printf("basedirname = %s\n", basedirname);
-    }
-
-    if (basedirname) {
-      snprintf(tmp, sizeof(tmp) - 1, "%s/%s", basedirname, filename);
-    } else {
-      strncpy(tmp, filename, strlen(filename) + 1);
-    }
-
-    printf("tmp = %s\n", tmp);
-
-    if (basedirname) {
-      free(basedirname);
-    }
-
-    *data = mmap_file(&data_len, tmp);
-  }
-
+  *data = mmap_file(&data_len, filename);
   (*len) = data_len;
 }
 

--- a/test/fixtures/cube.obj
+++ b/test/fixtures/cube.obj
@@ -1,10 +1,7 @@
 # Blender v2.79 (sub 0) OBJ File: ''
 # www.blender.org
 
-# TODO: this should not be a relative path, but is being opened by the process
-# running in the parent folder.
-# See discussion from https://github.com/syoyo/tinyobjloader-c/issues/4#issuecomment-289190334
-mtllib fixtures/cube.mtl
+mtllib cube.mtl
 
 o Cube
 v 1.000000 -1.000000 -1.000000

--- a/test/fixtures/negative-exponent.obj
+++ b/test/fixtures/negative-exponent.obj
@@ -1,10 +1,7 @@
 # Blender v2.79 (sub 0) OBJ File: ''
 # www.blender.org
 
-# TODO: this should not be a relative path, but is being opened by the process
-# running in the parent folder.
-# See discussion from https://github.com/syoyo/tinyobjloader-c/issues/4#issuecomment-289190334
-mtllib fixtures/cube.mtl
+mtllib cube.mtl
 
 o Cube
 v 2.0e+5 2.0e-5 2.0e-0

--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -1302,16 +1302,32 @@ static size_t basename_len(const char *filename, size_t filename_length) {
   const char *p = &filename[filename_length - 1];
   size_t count = 1;
 
-  while (*(--p) != '/') {
-    if (p == filename) {
-	  count = filename_length;
-	  return count;
+  /* On Windows, the directory delimiter is '\' and both it and '/' is
+   * reserved by the filesystem. On *nix platforms, only the '/' character 
+   * is reserved, so account for the two cases separately. */
+  #if _WIN32
+    while (p[-1] != '/' && p[-1] != '\\') {
+      if (p == filename) {
+	    count = filename_length;
+	    return count;
+      }
+      count++;
+	  p--;
     }
-    count++;
-
-  }
-
-  return count;
+	p++;
+    return count;
+  #else
+    while (*(--p) != '/') {
+      if (p == filename) {
+	    count = filename_length;
+	    return count;
+      }
+      count++;
+    }
+    return count;
+  #endif
+  
+ 
 }
 
 static char *generate_mtl_filename(const char *obj_filename,

--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -1074,7 +1074,7 @@ static int tinyobj_parse_and_index_mtl_file(tinyobj_material_t **materials_out,
 int tinyobj_parse_mtl_file(tinyobj_material_t **materials_out,
                            size_t *num_materials_out,
                            const char *mtl_filename, const char *obj_filename, file_reader_callback file_reader,
-			   void *ctx) {
+                           void *ctx) {
   return tinyobj_parse_and_index_mtl_file(materials_out, num_materials_out, mtl_filename, obj_filename, file_reader, ctx, NULL);
 }
 
@@ -1298,7 +1298,7 @@ static int parseLine(Command *command, const char *p, size_t p_len,
 }
 
 static size_t basename_len(const char *filename, size_t filename_length) {
-  	/* Count includes NUL terminator. */
+  /* Count includes NUL terminator. */
   const char *p = &filename[filename_length - 1];
   size_t count = 1;
 
@@ -1308,32 +1308,30 @@ static size_t basename_len(const char *filename, size_t filename_length) {
   #if _WIN32
     while (p[-1] != '/' && p[-1] != '\\') {
       if (p == filename) {
-	    count = filename_length;
-	    return count;
+        count = filename_length;
+        return count;
       }
       count++;
-	  p--;
+      p--;
     }
-	p++;
+    p++;
     return count;
   #else
     while (*(--p) != '/') {
       if (p == filename) {
-	    count = filename_length;
-	    return count;
+        count = filename_length;
+        return count;
       }
       count++;
     }
     return count;
   #endif
-  
- 
 }
 
 static char *generate_mtl_filename(const char *obj_filename,
-								   size_t obj_filename_length,
-								   const char *mtllib_name,
-								   size_t mtllib_name_length) {
+                                   size_t obj_filename_length,
+                                   const char *mtllib_name,
+                                   size_t mtllib_name_length) {
   /* Create a dynamically-allocated material filename. This allows the material
    * and obj files to be separated, however the mtllib name in the OBJ file
    * must be a relative path to the material file from the OBJ's directory.
@@ -1360,7 +1358,7 @@ static char *generate_mtl_filename(const char *obj_filename,
 int tinyobj_parse_obj(tinyobj_attrib_t *attrib, tinyobj_shape_t **shapes,
                       size_t *num_shapes, tinyobj_material_t **materials_out,
                       size_t *num_materials_out, const char *obj_filename,
-		      file_reader_callback file_reader, void *ctx,
+                      file_reader_callback file_reader, void *ctx,
                       unsigned int flags) {
   LineInfo *line_infos = NULL;
   Command *commands = NULL;
@@ -1437,25 +1435,25 @@ int tinyobj_parse_obj(tinyobj_attrib_t *attrib, tinyobj_shape_t **shapes,
       commands[mtllib_line_index].mtllib_name_len > 0) {
     /* Maximum length allowed by Linux - higher than Windows and macOS */
     size_t obj_filename_len = my_strnlen(obj_filename, 4096 + 255) + 1;
-	char *mtl_filename;
+    char *mtl_filename;
     char *mtllib_name;
     size_t mtllib_name_len = 0;
     int ret;
-		
+
     mtllib_name_len = length_until_line_feed(commands[mtllib_line_index].mtllib_name,
                                              commands[mtllib_line_index].mtllib_name_len);
-	  
+
     mtllib_name = my_strndup(commands[mtllib_line_index].mtllib_name,
                              mtllib_name_len);
-	
+
     /* allow for NUL terminator */
     mtllib_name_len++;
     mtl_filename = generate_mtl_filename(obj_filename, obj_filename_len,
                                          mtllib_name, mtllib_name_len);
-	  
+
     ret = tinyobj_parse_and_index_mtl_file(&materials, &num_materials,
                                            mtl_filename, obj_filename,
-	                                       file_reader, ctx,
+                                           file_reader, ctx,
                                            &material_table);
 
     if (ret != TINYOBJ_SUCCESS) {


### PR DESCRIPTION
Hi Syoyo,
Up until now, the callback function written by the client was responsible for finding and loading the material file for the respective obj file. This commit changes this and allows the library to find the material file based on the mtllib listing in the OBJ file, then pass that name through to the callback to load the file.

The benefit of this is as follows: 1. the client library does not need to worry about extracting the material file's name from the obj name anymore. 2. The functions are written carefully so that the location of the material file is calculated relative to the OBJ file, so the MTL and OBJ files can live in seperate directories if the user chooses, as long as the mtllib line of the OBJ file has the path, relative to itself. 3. Client callbacks can be simplified to merely extract the file, making client integration easier.

With the above said, it should be noted that this is a breaking change, because if the client tries to manipulate the MTL file path, there is a risk it will not be able to find the file. Thus, I would prefer a discussion on whether this approach would be a good one or not, for the project's future and how it wants to approach MTL file discovery and loading.

Thank you for your time and consideration. 