### PR TITLE
Fix unbounded writing of sscanf

### DIFF
--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -915,7 +915,7 @@ static int tinyobj_parse_and_index_mtl_file(tinyobj_material_t **materials_out,
 #ifdef _MSC_VER
       sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
 #else
-      sscanf(token, "%s", namebuf);
+      sscanf(token, "%4095s", namebuf);
 #endif
       material.name = my_strdup(namebuf, (size_t) (line_end - token));
 


### PR DESCRIPTION
'%s' may lead to buffer overflow if the width is not provided.