### PR TITLE
"Triangulate" flag breaks `shape.offset_index`

### DIFF
--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -1647,7 +1647,11 @@ int tinyobj_parse_obj(tinyobj_attrib_t *attrib, tinyobj_shape_t **shapes,
         }
       }
       if (commands[i].type == COMMAND_F) {
-        face_count++;
+        if (flags & TINYOBJ_FLAG_TRIANGULATE) {
+          face_count += commands[i].num_f_num_verts;
+        } else {
+          face_count++;
+        }
       }
     }
 


### PR DESCRIPTION
I wanted to load a [model](https://people.sc.fsu.edu/~jburkardt/data/obj/al.obj) I downloaded from [this](https://people.sc.fsu.edu/~jburkardt/data/obj/obj.html) site.
Besides having to make `TINYOBJ_MAX_FACES_PER_F_LINE` bigger, I stumbled across a problem with shape indexes.
The model is suppose to look like something like this: ![preview of the model](https://people.sc.fsu.edu/~jburkardt/data/obj/al.png).
_It works when I render whole vertex buffer_ but when I **try to render individual shapes** it looks really weird:
![model with highlighted shapes and wrong indexing](https://github.com/syoyo/tinyobjloader-c/assets/6958911/d07813db-8fc2-456b-88cd-cd936fa3c64a)
Now I don't know what 1/2 of the variable names mean but I figured adding `commands[i].num_f_num_verts` to `face_count` instead of `1` would fix the problem and **it did**:
![al_correct_shape_offsets](https://github.com/syoyo/tinyobjloader-c/assets/6958911/8941990e-4062-470c-a5e7-c29ef06614fe)
