### PR TITLE
Fix the 'more chars after last line' check

### DIFF
--- a/test/tinyobj_internal_tests.c
+++ b/test/tinyobj_internal_tests.c
@@ -140,6 +140,56 @@ void test_length_until_newline(void)
     }
 }
 
+void test_num_lines(void) {
+	{
+		char buf[] = "";
+		LineInfo *line_infos = NULL;
+		size_t num_lines = 0;
+		get_line_infos(buf, sizeof(buf) - 1, &line_infos, &num_lines);
+		TEST_CHECK(num_lines == 0);
+	}
+
+	{
+		char buf[] = "hello";
+		LineInfo *line_infos = NULL;
+		size_t num_lines = 0;
+		get_line_infos(buf, sizeof(buf) - 1, &line_infos, &num_lines);
+		TEST_CHECK(num_lines == 1);
+	}
+
+	{
+		char buf[] = "\n\n";
+		LineInfo *line_infos = NULL;
+		size_t num_lines = 0;
+		get_line_infos(buf, sizeof(buf) - 1, &line_infos, &num_lines);
+		TEST_CHECK(num_lines == 2);
+	}
+
+	{
+		char buf[] = "a\r\na\na\0";
+		LineInfo *line_infos = NULL;
+		size_t num_lines = 0;
+		get_line_infos(buf, sizeof(buf) - 1, &line_infos, &num_lines);
+		TEST_CHECK(num_lines == 3);
+	}
+
+	{
+		char buf[] = "hello\nworld\n";
+		LineInfo *line_infos = NULL;
+		size_t num_lines = 0;
+		get_line_infos(buf, sizeof(buf) - 1, &line_infos, &num_lines);
+		TEST_CHECK(num_lines == 2);
+	}
+
+	{
+		char buf[] = "hello\nworld\n!";
+		LineInfo *line_infos = NULL;
+		size_t num_lines = 0;
+		get_line_infos(buf, sizeof(buf) - 1, &line_infos, &num_lines);
+		TEST_CHECK(num_lines == 3);
+	}
+}
+
 void test_my_atoi(void)
 {
     // Results for input strings should become corresponding ints.

--- a/test/tinyobj_internal_tests.h
+++ b/test/tinyobj_internal_tests.h
@@ -5,6 +5,7 @@ void test_skip_space(void);
 void test_skip_space_and_cr(void);
 void test_until_space(void);
 void test_length_until_newline(void);
+void test_num_lines(void);
 void test_my_atoi(void);
 void test_fix_index(void);
 void test_parseRawTriple(void);

--- a/test/tinyobj_tests.c
+++ b/test/tinyobj_tests.c
@@ -15,6 +15,7 @@ TEST_LIST = {
     { "skip_space_and_cr",      test_skip_space_and_cr },
     { "until_space",            test_until_space },
     { "length_until_newline",   test_length_until_newline },
+    { "num_lines",              test_num_lines },
     { "my_atoi",                test_my_atoi },
     { "fix_index",              test_fix_index },
     { "parseRawTriple",         test_parseRawTriple },

--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -810,7 +810,7 @@ static int get_line_infos(const char *buf, size_t buf_len, LineInfo **line_infos
     * ending character so add an extra line if there
     * are more characters after the last line ending
     * that was found. */
-  if (end_idx - last_line_ending > 0) {
+  if (end_idx - last_line_ending > 1) {
       (*num_lines)++;
   }
 
@@ -827,7 +827,7 @@ static int get_line_infos(const char *buf, size_t buf_len, LineInfo **line_infos
       line_no++;
     }
   }
-  if (end_idx - last_line_ending > 0) {
+  if (end_idx - last_line_ending > 1) {
     (*line_infos)[line_no].pos = prev_pos;
     (*line_infos)[line_no].len = end_idx - 1 - last_line_ending;
   }


### PR DESCRIPTION
The current condition expects the last char on the file to be on `end_idx`, but actually it will be at `end_idx - 1`. So, change the allowed difference between `end_idx` and `last_line_ending` from 0 to 1.