### PR TITLE
Moved implementation outside of the header guard

### DIFF
--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -150,6 +150,7 @@ extern void tinyobj_materials_free(tinyobj_material_t *materials,
 #ifdef __cplusplus
 }
 #endif
+#endif /* TINOBJ_LOADER_C_H_ */
 
 #ifdef TINYOBJ_LOADER_C_IMPLEMENTATION
 #include <stdio.h>
@@ -1732,5 +1733,3 @@ void tinyobj_materials_free(tinyobj_material_t *materials,
   TINYOBJ_FREE(materials);
 }
 #endif /* TINYOBJ_LOADER_C_IMPLEMENTATION */
-
-#endif /* TINOBJ_LOADER_C_H_ */


### PR DESCRIPTION
I have encountered a problem when tried to use this library:
```c
/* only include definitions */
#include "tinyobj_loader_c.h"

/* my code that may have conflict with tinyobj_loader_c implementation */

/* implementation later in the source file */
#define TINYOBJ_LOADER_C_IMPLEMENTATION
#include "tinyobj_loader_c.h"
```
I cannot do this since the header guard is preventing me from including the file twice which the implementation is inside.
So, I move the implementation outside of the header guard. :)