### PR TITLE
fix: skip trailing whitespace in mtl names (issue 69)

### DIFF
--- a/test/fixtures/cube-trailing-space.obj
+++ b/test/fixtures/cube-trailing-space.obj
@@ -1,0 +1,33 @@
+# Blender v2.79 (sub 0) OBJ File: ''
+# www.blender.org
+
+# with one trailing space
+mtllib cube.mtl 
+
+o Cube
+v 1.000000 -1.000000 -1.000000
+v 1.000000 -1.000000 1.000000
+v -1.000000 -1.000000 1.000000
+v -1.000000 -1.000000 -1.000000
+v 1.000000 1.000000 -0.999999
+v 0.999999 1.000000 1.000001
+v -1.000000 1.000000 1.000000
+v -1.000000 1.000000 -1.000000
+vn 0.0000 -1.0000 0.0000
+vn 0.0000 1.0000 0.0000
+vn 1.0000 0.0000 0.0000
+vn -0.0000 -0.0000 1.0000
+vn -1.0000 -0.0000 -0.0000
+vn 0.0000 0.0000 -1.0000
+# with two trailing spaces and two trailing tabs
+usemtl CubeMaterial     
+s off
+f 1//1 2//1 3//1 4//1
+f 5//2 8//2 7//2 6//2
+f 1//3 5//3 6//3 2//3
+f 2//4 6//4 7//4 3//4
+f 3//5 7//5 8//5 4//5
+f 5//6 1//6 4//6 8//6
+
+# TODO: Remove extra content at the end of the file when
+# https://github.com/syoyo/tinyobjloader-c/issues/12 is fixed

--- a/test/tinyobj_internal_tests.c
+++ b/test/tinyobj_internal_tests.c
@@ -138,15 +138,15 @@ void test_length_until_newline(void)
     }
 
     {
-        // Return value for null-terminated string without line breaks should be
-        // number of non-null chars.
+        // Return value for null-terminated string with trailing spaces should be
+        // number of non-null chars without number of trailing spaces.
         char test_string[] = "potato    ";
         TEST_CHECK(length_until_newline(test_string, sizeof(test_string)) == 6);
     }
 
     {
-        // Return value for null terminated string with a linebreak at the end should
-        // be number of chars to newline.
+        // Return value for null-terminated string with trailing spaces should be
+        // number of non-null chars without number of trailing spaces.
         char test_string[] = "potato \n";
         TEST_CHECK(length_until_newline(test_string, sizeof(test_string)) == 6);
     }

--- a/test/tinyobj_internal_tests.c
+++ b/test/tinyobj_internal_tests.c
@@ -136,6 +136,20 @@ void test_length_until_newline(void)
         char test_string[] = "pot\0ato";
         TEST_CHECK(length_until_newline(test_string, sizeof(test_string)) == 7);
     }
+
+    {
+        // Return value for null-terminated string without line breaks should be
+        // number of non-null chars.
+        char test_string[] = "potato    ";
+        TEST_CHECK(length_until_newline(test_string, sizeof(test_string)) == 6);
+    }
+
+    {
+        // Return value for null terminated string with a linebreak at the end should
+        // be number of chars to newline.
+        char test_string[] = "potato \n";
+        TEST_CHECK(length_until_newline(test_string, sizeof(test_string)) == 6);
+    }
 }
 
 void test_num_lines(void) {

--- a/test/tinyobj_regression_tests.c
+++ b/test/tinyobj_regression_tests.c
@@ -83,6 +83,30 @@ void test_tinyobj_negative_exponent(void)
     }
 }
 
+void test_tinyobj_skip_whitespace(void)
+{
+    {
+        const char * filename = "fixtures/cube-trailing-space.obj";
+
+        tinyobj_shape_t * shape = NULL;
+        tinyobj_material_t * material = NULL;
+        tinyobj_attrib_t attrib;
+
+        unsigned long num_shapes;
+        unsigned long num_materials;
+
+        tinyobj_attrib_init(&attrib);
+
+        int result = tinyobj_parse_obj(&attrib, &shape, &num_shapes, &material, &num_materials, filename, loadFile, NULL, TINYOBJ_FLAG_TRIANGULATE);
+
+        TEST_CHECK(result == TINYOBJ_SUCCESS);
+
+        // TODO: should these two values be swapped?
+        TEST_CHECK(num_materials == 1);
+        TEST_CHECK(strcmp(material->name, "CubeMaterial") == 0);
+    }
+}
+
 void test_hash_table_infinity_loop(void)
 {
     hash_table_t table;

--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -210,6 +210,7 @@ static size_t length_until_newline(const char *token, size_t n) {
   size_t len = 0;
 
   /* Assume token[n-1] = '\0' */
+  assert(token[n-1] == '\0');
   for (len = 0; len < n - 1; len++) {
     if (token[len] == '\n') {
       break;
@@ -219,10 +220,8 @@ static size_t length_until_newline(const char *token, size_t n) {
     }
   }
   /* remove trailing whitespace */
-  for (; len > 0; len--) {
-    if (token[len] != ' ') {
-      break;
-    }
+  while (len > 0 && token[len - 1] == ' ') {
+    len--;
   }
 
   return len;
@@ -1307,8 +1306,7 @@ static int parseLine(Command *command, const char *p, size_t p_len,
     skip_space(&token);
     command->mtllib_name = p + (token - linebuf);
     command->mtllib_name_len = (unsigned int)length_until_newline(
-                                                                  token, p_len - (size_t)(token - linebuf)) +
-      1;
+                                                                  token, (p_len - (size_t)(token - linebuf)) + 1);
     command->type = COMMAND_MTLLIB;
 
     return 1;
@@ -1321,8 +1319,7 @@ static int parseLine(Command *command, const char *p, size_t p_len,
 
     command->group_name = p + (token - linebuf);
     command->group_name_len = (unsigned int)length_until_newline(
-                                                                 token, p_len - (size_t)(token - linebuf)) +
-      1;
+                                                                 token, (p_len - (size_t)(token - linebuf)) + 1);
     command->type = COMMAND_G;
 
     return 1;

--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -218,6 +218,12 @@ static size_t length_until_newline(const char *token, size_t n) {
       break;
     }
   }
+  /* remove trailing whitespace */
+  for (; len > 0; len--) {
+    if (token[len] != ' ') {
+      break;
+    }
+  }
 
   return len;
 }

--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -220,7 +220,7 @@ static size_t length_until_newline(const char *token, size_t n) {
     }
   }
   /* remove trailing whitespace */
-  while (len > 0 && token[len - 1] == ' ') {
+  while (len > 0 && IS_SPACE(token[len - 1])) {
     len--;
   }
 

--- a/tinyobj_loader_c.h
+++ b/tinyobj_loader_c.h
@@ -1332,8 +1332,7 @@ static int parseLine(Command *command, const char *p, size_t p_len,
 
     command->object_name = p + (token - linebuf);
     command->object_name_len = (unsigned int)length_until_newline(
-                                                                  token, p_len - (size_t)(token - linebuf)) +
-      1;
+                                                                  token, (p_len - (size_t)(token - linebuf)) + 1);
     command->type = COMMAND_O;
 
     return 1;


### PR DESCRIPTION
fixes #69. If the mtl file contains any space at the end, but before the newline, the mtl file is not found. 

all tests pass. 
the viewer now loads the mtl file

before:
```c
Initialize GLFW...
open: No such file or directory
TINYOBJ: Failed to parse material file '/home/me/documents/inf/tuxtown/assets/kenney_furniture-kit/Models/OBJ format/floorFull.mtl ': -2
# of shapes    = 2
# of materials = 0
bmin = -1.000000, 0.000000, 0.000000
bmax = 0.000000, 0.050000, 1.000000
```
after:
```c
Initialize GLFW...
# of shapes    = 2
# of materials = 1
bmin = -1.000000, 0.000000, 0.000000
bmax = 0.000000, 0.050000, 1.000000
```